### PR TITLE
Update HoughMorphClassifier.py

### DIFF
--- a/sfft/utils/HoughMorphClassifier.py
+++ b/sfft/utils/HoughMorphClassifier.py
@@ -135,7 +135,9 @@ class Hough_MorphClassifier:
         """
 
         skimage_version = parse_version(skimage.__version__)
-        assert parse_version('0.16.1') <= skimage_version <= parse_version('0.18.3')
+            
+        #Is this nessecary - conflicts with photutils 1.13.1   
+        #assert parse_version('0.16.1') <= skimage_version <= parse_version('0.18.3')
         
         A_IMAGE = np.array(AstSEx['A_IMAGE'])
         B_IMAGE = np.array(AstSEx['B_IMAGE'])


### PR DESCRIPTION
(Duplicate is issue)

Is this necessary? - as the code seems to work find with the latest version of scikit-image

Using outdated versions conflicts with the latest photutils packages